### PR TITLE
Make the installation of golangci-lint faster.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,10 +209,10 @@ artifacts/archives/$(PROJECT_NAME)-$(GO_APP_VERSION)-%.zip: $(GO_ARCHIVE_FILES) 
 	@rm -f "$@"
 	zip --recurse-paths --junk-paths "$@" -- $^
 
-artifacts/go/bin/go.mod:
+artifacts/go/bin/golangci-lint:
 	$(MF_ROOT)/pkg/go/v1/bin/install-golangci-lint "$(MF_PROJECT_ROOT)/$(@D)"
 
-artifacts/go/lint/golangci-lint.touch: artifacts/go/bin/go.mod $(GO_SOURCE_FILES)
+artifacts/go/lint/golangci-lint.touch: artifacts/go/bin/golangci-lint $(GO_SOURCE_FILES)
 	artifacts/go/bin/golangci-lint run --config $(MF_ROOT)/pkg/go/v1/etc/.golangci.yml ./...
 
 	@mkdir -p "$(@D)"

--- a/bin/install-golangci-lint
+++ b/bin/install-golangci-lint
@@ -1,19 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export GOBIN="$1"
-mkdir -p "$GOBIN"
-cd "$GOBIN"
-
-# Create a go mod just for this binary, to avoid messing with the project's
-# own go.mod.
-if [ ! -f go.mod ]; then
-    go mod init bin
-fi
-
-# Install the latest version of the linter into this "bin" module.
-go get "github.com/golangci/golangci-lint/cmd/golangci-lint@latest"
-
-# Touch the go.mod file so that it is no longer considered out of date by make,
-# even if nothing actually changed.
-touch go.mod
+# Get the latest version of the golangci-lint linter.
+VERSION="$(curl --head --silent https://github.com/golangci/golangci-lint/releases/latest | grep -i '^Location:' | egrep -o '[0-9]+.[0-9]+.[0-9]+')"
+# Install it in the directory specified in the first argument of this script.
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$1" "v${VERSION}"


### PR DESCRIPTION
This PR makes the installation of the `golangci-lint` linter faster as per the [original installation recommendations](https://golangci-lint.run/usage/install/).