### PR TITLE
replace GO_MATRIX_ARCH and GO_MATRIX_OS with GO_MATRIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,8 @@ _GO_BINARIES_HOST = $(_GO_BINARIES_NIX)
 endif
 
 # _GO_BUILD_PLATFORM_MATRIX_xxx is the cartesian product of GO_MATRIX (containing os/arch)
-# and all operating systems and architectures specified in GO_MATRIX_OS and GO_MATRIX_ARCH.
+# and backwards compatible to the deprecated combination of all operating systems and 
+# architectures specified in GO_MATRIX_OS and GO_MATRIX_ARCH.
 _GO_BUILD_PLATFORM_MATRIX_ALL  = $(sort $(foreach OS,$(GO_MATRIX_OS),$(foreach ARCH,$(GO_MATRIX_ARCH),$(OS)/$(ARCH))) $(GO_MATRIX))
 _GO_BUILD_PLATFORM_MATRIX_NIX  = $(filter-out windows/%,$(_GO_BUILD_PLATFORM_MATRIX_ALL))
 _GO_BUILD_PLATFORM_MATRIX_WIN  = $(filter windows/%,$(_GO_BUILD_PLATFORM_MATRIX_ALL))

--- a/Makefile
+++ b/Makefile
@@ -82,9 +82,9 @@ else
 _GO_BINARIES_HOST = $(_GO_BINARIES_NIX)
 endif
 
-# _GO_BUILD_PLATFORM_MATRIX_xxx is the cartesian product of GO_MATRIX (containing os/arch)
-# and backwards compatible to the deprecated combination of all operating systems and 
-# architectures specified in GO_MATRIX_OS and GO_MATRIX_ARCH.
+# _GO_BUILD_PLATFORM_MATRIX_ALL is the union of GO_MATRIX (containing os/arch) and the
+# cartesian product of all operating systems and architectures specified in
+# GO_MATRIX_OS and GO_MATRIX_ARCH (which are now deprecated).
 _GO_BUILD_PLATFORM_MATRIX_ALL  = $(sort $(foreach OS,$(GO_MATRIX_OS),$(foreach ARCH,$(GO_MATRIX_ARCH),$(OS)/$(ARCH))) $(GO_MATRIX))
 _GO_BUILD_PLATFORM_MATRIX_NIX  = $(filter-out windows/%,$(_GO_BUILD_PLATFORM_MATRIX_ALL))
 _GO_BUILD_PLATFORM_MATRIX_WIN  = $(filter windows/%,$(_GO_BUILD_PLATFORM_MATRIX_ALL))

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,11 @@ _GO_BUILD_PLATFORM_MATRIX_NIX  = $(filter-out windows/%,$(_GO_BUILD_PLATFORM_MAT
 _GO_BUILD_PLATFORM_MATRIX_WIN  = $(filter windows/%,$(_GO_BUILD_PLATFORM_MATRIX_ALL))
 _GO_BUILD_PLATFORM_MATRIX_HOST = $(GOHOSTOS)/$(GOHOSTARCH)
 
+# Print deprecation warnings if GO_MATRIX_ARCH or GO_MATRIX_OS is used.
+ifneq ($(GO_MATRIX_ARCH)$(GO_MATRIX_OS),)
+$(warning GO_MATRIX_ARCH/GO_MATRIX_OS is deprecated, change to GO_MATRIX = $(_GO_BUILD_PLATFORM_MATRIX_ALL))
+endif
+
 # _GO_BUILD_MATRIX_xxx is the cartesian product of the platform matrix and the
 # filenames of the binaries.
 _GO_BUILD_MATRIX_NIX  = $(foreach P,$(_GO_BUILD_PLATFORM_MATRIX_NIX),$(addprefix $(P)/,$(_GO_BINARIES_NIX)))

--- a/Makefile
+++ b/Makefile
@@ -35,19 +35,13 @@ GO_APP_VERSION ?= $(SEMVER)
 GO_DEBUG_ARGS   ?= -v -ldflags "-X main.version=$(GO_APP_VERSION)"
 GO_RELEASE_ARGS ?= -v -ldflags "-X main.version=$(GO_APP_VERSION) -s -w"
 
+
 # Build matrix configuration.
 #
-# GO_MATRIX_OS is a whitespace separated set of operating systems.
-# GO_MATRIX_ARCH is a whitespace separated set of CPU architectures.
-#
-# The build-matrix is constructed from all permutations of GO_MATRIX_OS and
-# GO_MATRIX_ARCH. The default is to build only for the OS and architecture
-# specified by the GOHOSTOS and GOHOSTARCH environment variables, that is the OS
-# and architecture of current system.
+# GO_MATRIX is a whitespace separated set of operating systems and architectures.
 GOHOSTOS   := $(shell go env GOHOSTOS)
 GOHOSTARCH := $(shell go env GOHOSTARCH)
-GO_MATRIX_OS   ?= $(GOHOSTOS)
-GO_MATRIX_ARCH ?= $(GOHOSTARCH)
+GO_MATRIX  ?= $(GOHOSTOS)/$(GOHOSTARCH)
 
 # GO_TEST_REQ is a space separated list of prerequisites needed to run tests.
 GO_TEST_REQ +=
@@ -88,9 +82,9 @@ else
 _GO_BINARIES_HOST = $(_GO_BINARIES_NIX)
 endif
 
-# _GO_BUILD_PLATFORM_MATRIX_xxx is the cartesian product of all operating
-# systems and architectures specified in GO_MATRIX_OS and GO_MATRIX_ARCH.
-_GO_BUILD_PLATFORM_MATRIX_ALL  = $(foreach OS,$(GO_MATRIX_OS),$(foreach ARCH,$(GO_MATRIX_ARCH),$(OS)/$(ARCH)))
+# _GO_BUILD_PLATFORM_MATRIX_xxx is the cartesian product of GO_MATRIX (containing os/arch)
+# and all operating systems and architectures specified in GO_MATRIX_OS and GO_MATRIX_ARCH.
+_GO_BUILD_PLATFORM_MATRIX_ALL  = $(sort $(foreach OS,$(GO_MATRIX_OS),$(foreach ARCH,$(GO_MATRIX_ARCH),$(OS)/$(ARCH))) $(GO_MATRIX))
 _GO_BUILD_PLATFORM_MATRIX_NIX  = $(filter-out windows/%,$(_GO_BUILD_PLATFORM_MATRIX_ALL))
 _GO_BUILD_PLATFORM_MATRIX_WIN  = $(filter windows/%,$(_GO_BUILD_PLATFORM_MATRIX_ALL))
 _GO_BUILD_PLATFORM_MATRIX_HOST = $(GOHOSTOS)/$(GOHOSTARCH)

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,11 @@ GO_RELEASE_ARGS ?= -v -ldflags "-X main.version=$(GO_APP_VERSION) -s -w"
 # GO_MATRIX is a whitespace separated set of operating systems and architectures.
 GOHOSTOS   := $(shell go env GOHOSTOS)
 GOHOSTARCH := $(shell go env GOHOSTARCH)
+ifneq ($(GO_MATRIX_ARCH)$(GO_MATRIX_OS),)
+GO_MATRIX  ?=
+else
 GO_MATRIX  ?= $(GOHOSTOS)/$(GOHOSTARCH)
+endif
 
 # GO_TEST_REQ is a space separated list of prerequisites needed to run tests.
 GO_TEST_REQ +=


### PR DESCRIPTION
Replacing `GO_MATRIX_ARCH` and `GO_MATRIX_OS` with just `GO_MATRIX`.

So previously a Makefile would have: 
```Makefile
GO_MATRIX_OS ?= linux
GO_MATRIX_ARCH ?= arm5 arm7
```

but now it will have:
```Makefile
GO_MATRIX += linux/arm_v5 linux/arm_v7
```

A more complete example would be:
```Makefile
GO_MATRIX += darwin/amd64 darwin/arm64
GO_MATRIX += linux/amd64 linux/arm64 linux/arm_v7 linux/arm_v5
GO_MATRIX += windows/amd64 windows/arm_v7
```